### PR TITLE
Add user caching with cross-pod eviction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,10 @@
             <artifactId>spring-kafka</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/src/main/java/com/example/users/UserCacheEvictConsumer.java
+++ b/src/main/java/com/example/users/UserCacheEvictConsumer.java
@@ -1,0 +1,25 @@
+package com.example.users;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserCacheEvictConsumer {
+    private final CacheManager cacheManager;
+
+    @KafkaListener(
+            topics = "${user.cache.evict.topic:user-cache-evict}",
+            groupId = "#{T(java.util.UUID).randomUUID().toString()}"
+    )
+    public void listen(String cacheName) {
+        log.info("Evicting cache {} based on message", cacheName);
+        Optional.ofNullable(cacheManager.getCache(cacheName)).ifPresent(Cache::clear);
+    }
+}

--- a/src/main/java/com/example/users/UserCacheEvictProducer.java
+++ b/src/main/java/com/example/users/UserCacheEvictProducer.java
@@ -1,0 +1,27 @@
+package com.example.users;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class UserCacheEvictProducer {
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final CacheManager cacheManager;
+
+    @Value("${user.cache.evict.topic:user-cache-evict}")
+    private String topic;
+
+    public void evictUsersCache() {
+        Optional.ofNullable(cacheManager.getCache("users")).ifPresent(Cache::clear);
+        log.info("Evicting users cache and notifying others");
+        kafkaTemplate.send(topic, "users");
+    }
+}

--- a/src/main/java/com/example/users/UserConsumer.java
+++ b/src/main/java/com/example/users/UserConsumer.java
@@ -10,10 +10,12 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserConsumer {
     private final UserRepository repository;
+    private final UserCacheEvictProducer cacheEvictProducer;
 
     @KafkaListener(topics = "${user.topic.name:users}", groupId = "users")
     public void listen(User user) {
         log.info("Persisting user {} from kafka", user.getName());
         repository.save(user);
+        cacheEvictProducer.evictUsersCache();
     }
 }

--- a/src/main/java/com/example/users/UserService.java
+++ b/src/main/java/com/example/users/UserService.java
@@ -1,6 +1,7 @@
 package com.example.users;
 
 import java.util.List;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,12 +12,15 @@ import lombok.extern.slf4j.Slf4j;
 public class UserService {
     private final UserRepository repository;
     private final UserProducer producer;
+    private final UserCacheEvictProducer cacheEvictProducer;
 
     public void create(User user) {
         log.info("Queuing creation of user {}", user.getName());
         producer.sendUser(user);
+        cacheEvictProducer.evictUsersCache();
     }
 
+    @Cacheable("users")
     public List<User> findAll() {
         return repository.findAll();
     }
@@ -24,18 +28,22 @@ public class UserService {
     public void deleteById(Long id) {
         log.info("Deleting user with id {}", id);
         repository.deleteById(id);
+        cacheEvictProducer.evictUsersCache();
     }
 
     public void deleteByName(String name) {
         log.info("Deleting user with name {}", name);
         repository.deleteByName(name);
+        cacheEvictProducer.evictUsersCache();
     }
 
     public User updateSalary(Long id, Double salary) {
         return repository.findById(id).map(user -> {
             log.info("Updating salary for user {} to {}", id, salary);
             user.setSalary(salary);
-            return repository.save(user);
+            User saved = repository.save(user);
+            cacheEvictProducer.evictUsersCache();
+            return saved;
         }).orElseThrow(() -> new RuntimeException("User not found"));
     }
 }

--- a/src/main/java/com/example/users/UsersApplication.java
+++ b/src/main/java/com/example/users/UsersApplication.java
@@ -2,9 +2,11 @@ package com.example.users;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.kafka.annotation.EnableKafka;
 
 @EnableKafka
+@EnableCaching
 @SpringBootApplication
 public class UsersApplication {
     public static void main(String[] args) {


### PR DESCRIPTION
## Summary
- enable Spring Cache and add starter dependency
- cache user listing and broadcast eviction via Kafka
- evict cache on user data changes to keep pods in sync

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68a5aae5aeb483258d3b945599f2cbe4